### PR TITLE
get secrets from vault and verify incoming requests from Github

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .pytest_cache
 **/__pycache__/**
-config.json
+config.final.json
 .idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM tiangolo/uwsgi-nginx-flask:python3.6
 
-COPY ./requirements.txt .
+COPY ./requirements-docker.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
 ENV STATIC_INDEX 1
 COPY ./src /app
-COPY config.final.json /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN pip3 install -r requirements.txt
 
 ENV STATIC_INDEX 1
 COPY ./src /app
-COPY config.json /app
+COPY config.final.json /app

--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@ Actions taken by the webhook:
     
     
 ## Configuration
-The config requires 3 things:
+See the `config.json` file.
+The config requires 4 things:
 1. the YouTrack instance name
 1. a permanent [YouTrack API access token](https://www.jetbrains.com/help/youtrack/standalone/Manage-Permanent-Token.html)
+1. a secret token used by GitHub to secure the webhook: see https://developer.github.com/webhooks/securing/
 1. a dictionary from GitHub logins to YouTrack usernames
 
-See the `sample.config.json` file.
+If a config value is provided in the format "VAULT:path:key" in will be resolved by looking up the secret from vault.
 
 ## Tests
 To run tests :

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If a config value is provided in the format "VAULT:path:key" in will be resolved
 ## Deployment
 The app runs inside a docker container and is mapped to port 4567 on the host machine.
 To deploy:
-1. `pip3 intall -r requirements.txt`
+1. `pip3 install -r requirements.txt`
 1. `run --vault-auth` to first resolve secrets before running the app
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If a config value is provided in the format "VAULT:path:key" in will be resolved
 The app runs inside a docker container and is mapped to port 4567 on the host machine.
 To deploy:
 1. `pip3 intall -r requirements.txt`
-1. `run`
+1. `run --vault-auth` to first resolve secrets before running the app
 
 ## Tests
 To run tests :

--- a/README.md
+++ b/README.md
@@ -30,7 +30,16 @@ The config requires 4 things:
 
 If a config value is provided in the format "VAULT:path:key" in will be resolved by looking up the secret from vault.
 
+## Deployment
+The app runs inside a docker container and is mapped to port 4567 on the host machine.
+To deploy:
+1. `pip3 intall -r requirements.txt`
+1. `run`
+
 ## Tests
 To run tests :
 1. `pip3 install -r requirements-dev.txt --user`
 1. `pytest`
+
+## Teamcity
+On TC the script `./teamcity.sh` runs which runs tests and builds the docker image

--- a/config.json
+++ b/config.json
@@ -1,7 +1,9 @@
 {
   "youtrack_instance_name": "vimc",
-  "youtrack_token": "<PERM_TOKEN>",
+  "youtrack_token": "VAULT:secret/webhook/youtrack:token",
+  "github_secret": "VAULT:secret/webhook/github:secret",
   "users_dict": {
+    "MartinEden": "martin",
     "hillalex": "a.hill",
     "richfitz": "richfitz",
     "r-ash": "rob",

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "youtrack_instance_name": "vimc",
-  "youtrack_token": "VAULT:secret/webhook/youtrack:token",
-  "github_secret": "VAULT:secret/webhook/github:secret",
+  "youtrack_token": "VAULT:secret/youtrack-integration/youtrack:token",
+  "github_secret": "VAULT:secret/youtrack-integration/github:secret",
   "users_dict": {
     "MartinEden": "martin",
     "hillalex": "a.hill",

--- a/requirements-docker.txt
+++ b/requirements-docker.txt
@@ -1,0 +1,2 @@
+flask>=0.12.4
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 flask>=0.12.4
 requests
+hvac

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-flask>=0.12.4
-requests
 hvac

--- a/run
+++ b/run
@@ -1,11 +1,21 @@
 #!/usr/bin/env bash
 set -ex
 
+here=$(dirname $0)
+git_id=$(git rev-parse --short=7 HEAD)
+
+registry=docker.montagu.dide.ic.ac.uk:5000
+name=youtrack-integration-webhook
+
+if [ "$1" = "--use-vault" ]; then
+    . $here/vault_auth.sh
+fi
+
 python3 ./save_settings
 
-docker build \
-	--tag webhook .
-
-docker run --rm \
+docker run -d \
+    --restart always \
+    -v $PWD/config.final.json:/app/config.json \
     -p 4567:80 \
-    webhook
+    --name youtrack-integration \
+    $registry/$name:$git_id

--- a/run
+++ b/run
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 set -ex
 
-docker build --tag webhook .
+python3 ./save_settings
+
+docker build \
+	--tag webhook .
+
 docker run --rm \
     -p 4567:80 \
     webhook

--- a/save_settings
+++ b/save_settings
@@ -13,6 +13,7 @@ def resolve_secret(value):
     if not m:
         raise Exception("Invalid vault accessor '{}'".format(value))
     path, key = m.groups()
+
     client = hvac.Client(url=os.environ['VAULT_ADDR'],
                          token=os.environ['VAULT_TOKEN'])
 

--- a/save_settings
+++ b/save_settings
@@ -42,9 +42,7 @@ def save_settings():
     with open("config.json", 'r') as f:
         data = json.load(f)
         resolve_secrets(data)
-    with open("config.final.json", 'a'):  # Create file if does not exist
-        pass
-    with open("config.final.json", 'w') as f:
+    with open("config.final.json", 'w+') as f:
         f.write(json.dumps(data))
 
 

--- a/save_settings
+++ b/save_settings
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+import hvac
+import json
+import re
+import os
+
+
+def resolve_secret(value):
+    re_vault = re.compile("^VAULT:([^:]+):([^:]+)$")
+    if not value.startswith("VAULT:"):
+        return False, value
+    m = re_vault.match(value)
+    if not m:
+        raise Exception("Invalid vault accessor '{}'".format(value))
+    path, key = m.groups()
+    client = hvac.Client(url=os.environ['VAULT_ADDR'],
+                         token=os.environ['VAULT_TOKEN'])
+
+    if not client.is_authenticated():
+        raise Exception("You must be authenticated with vault.")
+
+    data = client.read(path)
+    if not data:
+        raise Exception("Did not find secret at '{}'".format(path))
+
+    if key not in data["data"]:
+        raise Exception("Did not find key '{}' at secret path '{}'".format(
+            key, path))
+    return True, data["data"][key]
+
+
+def resolve_secrets(dict):
+    for k, v in dict.items():
+        if type(v) == str:
+            updated, v = resolve_secret(v)
+            if updated:
+                dict[k] = v
+
+
+def save_settings():
+    with open("config.json", 'r') as f:
+        data = json.load(f)
+        resolve_secrets(data)
+    with open("config.final.json", 'a'):  # Create file if does not exist
+        pass
+    with open("config.final.json", 'w') as f:
+        f.write(json.dumps(data))
+
+
+save_settings()

--- a/src/app/YouTrackHelper.py
+++ b/src/app/YouTrackHelper.py
@@ -1,5 +1,8 @@
 import requests
+import re
 
+old_branch_pattern = re.compile(r"^i(\d+)($|[_-])")
+new_branch_pattern = re.compile(r"^(.+-\d+)($|[_-])")
 
 class YouTrackHelper:
     base_url = "https://{}.myjetbrains.com/youtrack/rest/"
@@ -36,3 +39,14 @@ class YouTrackHelper:
         if response.status_code == 401:
             raise Exception("Failed to authorize against YouTrack")
         return response
+
+    @staticmethod
+    def get_issue_id(branch_name):
+        old_match = old_branch_pattern.match(branch_name)
+        new_match = new_branch_pattern.match(branch_name)
+        if old_match:
+            return "VIMC-" + old_match.group(1)
+        elif new_match:
+            return new_match.group(1)
+        else:
+            return None

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -11,7 +11,7 @@ def load_settings():
     with open("config.json", 'r') as f:
         data = json.load(f)
     with open("config.json", 'w') as f:
-        f.write("")
+        f.write("")  # remove sensitive config from disk after reading it into memory
     return data
 
 

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,20 +1,23 @@
 #!/usr/bin/env python3
 from flask import Flask, request
-import json
 import re
+import hmac
+import hashlib
+import json
 
 from .YouTrackHelper import YouTrackHelper
 
-app = Flask(__name__)
-
 
 def load_settings():
-    with open("config.json", 'r') as f:
+    with open("config.final.json", 'r') as f:
         data = json.load(f)
     return data
 
 
 settings = load_settings()
+
+app = Flask(__name__)
+
 yt = YouTrackHelper(settings["youtrack_instance_name"], settings["youtrack_token"])
 
 old_branch_pattern = re.compile(r"^i(\d+)($|[_-])")
@@ -34,8 +37,13 @@ def get_issue_id(branch_name):
 
 @app.route('/pull-request/', methods=['POST'])
 def assign():
-    users = settings["users_dict"]
+
     payload = request.get_json()
+    hash_signature = request.headers["X-Hub-Signature"]
+
+    if not signature_matches(request.data, hash_signature):
+        return '', 401
+
     pr = payload["pull_request"]
     url = pr["html_url"]
 
@@ -45,6 +53,7 @@ def assign():
         return '', 200
 
     if payload["action"] == "review_requested":
+        users = settings["users_dict"]
         assignee = users[pr["requested_reviewers"][0]["login"]]
         yt.update_ticket(issue_id,
                          commands=[yt.set_state("Submitted"), yt.assign(assignee)],
@@ -63,3 +72,9 @@ def assign():
                              comment=url)
 
     return '', 200
+
+
+def signature_matches(payload, hash_signature):
+    secret = bytes(settings["github_secret"], 'latin1')
+    signature = 'sha1=' + hmac.new(secret, payload, hashlib.sha1).hexdigest()
+    return hmac.compare_digest(signature, hash_signature)

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 from flask import Flask, request
-import re
 import hmac
 import hashlib
 import json
@@ -9,8 +8,10 @@ from .YouTrackHelper import YouTrackHelper
 
 
 def load_settings():
-    with open("config.final.json", 'r') as f:
+    with open("config.json", 'r') as f:
         data = json.load(f)
+    with open("config.json", 'w') as f:
+        f.write("")
     return data
 
 
@@ -19,20 +20,6 @@ settings = load_settings()
 app = Flask(__name__)
 
 yt = YouTrackHelper(settings["youtrack_instance_name"], settings["youtrack_token"])
-
-old_branch_pattern = re.compile(r"^i(\d+)($|[_-])")
-new_branch_pattern = re.compile(r"^(.+-\d+)($|[_-])")
-
-
-def get_issue_id(branch_name):
-    old_match = old_branch_pattern.match(branch_name)
-    new_match = new_branch_pattern.match(branch_name)
-    if old_match:
-        return "VIMC-" + old_match.group(1)
-    elif new_match:
-        return new_match.group(1)
-    else:
-        return None
 
 
 @app.route('/pull-request/', methods=['POST'])
@@ -47,7 +34,7 @@ def assign():
     pr = payload["pull_request"]
     url = pr["html_url"]
 
-    issue_id = get_issue_id(pr["head"]["ref"])
+    issue_id = YouTrackHelper.get_issue_id(pr["head"]["ref"])
 
     if issue_id is None:
         return '', 200

--- a/teamcity.sh
+++ b/teamcity.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+git_id=$(git rev-parse --short=7 HEAD)
+git_branch=$(git symbolic-ref --short HEAD)
+
+pip3 install --quiet -r requirements-dev.txt
+pytest
+
+registry=docker.montagu.dide.ic.ac.uk:5000
+name=youtrack-integration-webhook
+
+commit_tag=$registry/$name:$git_id
+branch_tag=$registry/$name:$git_branch
+
+docker build -t $commit_tag -t $branch_tag .
+docker push $commit_tag
+docker push $branch_tag

--- a/tests/test_branch_matching.py
+++ b/tests/test_branch_matching.py
@@ -1,22 +1,22 @@
-from src.app.main import get_issue_id
+from src.app.YouTrackHelper import YouTrackHelper
 
 
 def test_can_match_old_branch_names():
-    result = get_issue_id("i637")
+    result = YouTrackHelper.get_issue_id("i637")
     assert result == "VIMC-637"
 
-    result = get_issue_id("i123_something")
+    result = YouTrackHelper.get_issue_id("i123_something")
     assert result == "VIMC-123"
 
 
 def test_can_match_new_branch_names():
-    result = get_issue_id("VIMC-637")
+    result = YouTrackHelper.get_issue_id("VIMC-637")
     assert result == "VIMC-637"
 
-    result = get_issue_id("mrc-123_something")
+    result = YouTrackHelper.get_issue_id("mrc-123_something")
     assert result == "mrc-123"
 
 
 def test_does_not_match_arbitrary_branch_names():
-    result = get_issue_id("refactor")
+    result = YouTrackHelper.get_issue_id("refactor")
     assert result is None

--- a/vault_auth.sh
+++ b/vault_auth.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -ex
+
+export VAULT_ADDR='https://support.montagu.dide.ic.ac.uk:8200'
+if [ "$VAULT_AUTH_GITHUB_TOKEN" = "" ]; then
+    echo -n "Please provide your GitHub personal access token for the vault: "
+    read -s token
+    echo ""
+    export VAULT_AUTH_GITHUB_TOKEN=${token}
+fi
+echo "Authenticating with the Vault"
+export VAULT_TOKEN=$(vault login --method=github --token-only)


### PR DESCRIPTION
* Added logic to verify request are coming from GitHub 
* Borrowing pattern (simplified for this simpler use case) from orderly-web-deploy for getting secrets out of the vault.
* Image now being built on TC

Next steps: deploy this on support and proxy it through the main Montagu deploy