### PR TITLE
Add mwoodbri to config

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,6 +9,7 @@
     "weshinsley": "w.hinsley",
     "EmmaLRussell": "e.russell",
     "Nicolas-Dolan": "nicolas.dolan08",
-    "carbowizzy": "y.anifowoshe"
+    "carbowizzy": "y.anifowoshe",
+    "mwoodbri": "mwoodbri"
   }
 }


### PR DESCRIPTION
Discovered I was missing from this file in process of enabling YT/GH integration for comet... in hindsight I haven't been assigned to any YT PRs by the GitHub Robot.